### PR TITLE
Streamline unique id handling

### DIFF
--- a/graph/model/RelationshipGraph.js
+++ b/graph/model/RelationshipGraph.js
@@ -316,6 +316,10 @@ RelationshipGraph.prototype.removeFamilyNode = function(familyNode) {
 
 /*** Constructor ***/
 function RelationshipGraph(gx, chartId) {
+  if (!chartId) {
+    chartId = RelationshipGraph.nextGraphId++;
+  }
+
   this.gx = gx; // GedcomX document (record or portion of a tree).
   this.chartId = chartId;
   this.personNodes = []; // array of PersonNode
@@ -326,3 +330,5 @@ function RelationshipGraph(gx, chartId) {
   addPersonNodes(this);
   addFamilyNodes(this);
 }
+
+RelationshipGraph.nextGraphId = 1;

--- a/graph/view/RelChartBuilder.js
+++ b/graph/view/RelChartBuilder.js
@@ -422,11 +422,10 @@ RelChartBuilder.prototype.insertBelow = function(origPerson, newPerson, generati
  * @param shouldIncludeDetails - Whether to include alternate names and facts in the chart initially.
  * @param shouldCompress - Whether to do collapsing initially.
  * @param isEditable - Flag for whether to include GedcomX editing functionality.
- * @param chartId - String that uniquely identifies this chart on the page. Needed when multiple charts are being rendered on the same page.
  */
-function RelChartBuilder(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable, chartId) {
+function RelChartBuilder(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable) {
   // Create a chart with PersonBoxes created, but no FamilyLines or Generations yet.
-  this.relChart = new RelationshipChart(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable, chartId);
+  this.relChart = new RelationshipChart(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable);
   this.ABOVE = true;
   this.BELOW = false;
   // Set of personIds remaining to be added to the chart.

--- a/graph/view/RelationshipChart.js
+++ b/graph/view/RelationshipChart.js
@@ -207,22 +207,17 @@ RelationshipChart.prototype.setPreviousPositions = function(prevRelChart) {
  * @param shouldIncludeDetails - Flag for whether to include person facts (false => just display names)
  * @param shouldCompress - Flag for whether to do vertical compression (false => each person on own line)
  * @param isEditable - Flag for whether to include edit controls (false => view only)
- * @param chartId - String that uniquely identifies this chart on the page. Needed when multiple charts are being rendered on the same page.
  * @constructor
  */
-function RelationshipChart(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable, chartId) {
-  if (!chartId) {
-    chartId = 'relChart1';
-  }
-
+function RelationshipChart(relGraph, $relChartDiv, shouldIncludeDetails, shouldCompress, isEditable) {
   this.relGraph = relGraph;
   this.isEditable = isEditable;
-  this.chartId = chartId;
+  this.chartId = this.relGraph.chartId;
   $relChartDiv.empty();
-  $relChartDiv.append($.parseHTML(`<div id='personNodes-${chartId}'></div>\n<div id='familyLines-${chartId}'></div>\n<div id='editControls-${chartId}'></div>`));
-  this.$personsDiv = $(`#personNodes-${chartId}`);
-  this.$familyLinesDiv = $(`#familyLines-${chartId}`);
-  this.$editControlsDiv = $(`#editControls-${chartId}`);
+  $relChartDiv.append($.parseHTML(`<div id='personNodes-${this.chartId}'></div>\n<div id='familyLines-${this.chartId}'></div>\n<div id='editControls-${this.chartId}'></div>`));
+  this.$personsDiv = $(`#personNodes-${this.chartId}`);
+  this.$familyLinesDiv = $(`#familyLines-${this.chartId}`);
+  this.$editControlsDiv = $(`#editControls-${this.chartId}`);
   this.personBoxes = []; // array of all PersonBoxes in the relationship chart, positioned top to bottom
   this.generations = []; // array of Generations that the persons are in, left to right
   this.familyLines = []; // array of family lines


### PR DESCRIPTION
Rather than having the graph and the chart accept an id, only provide
it to the graph, which can then transitively provide it to the chart.

Also, use an auto-incrementing default id when the user doesn't
provide one.