### PR TITLE
Fixes loading our truth gedcomx.

### DIFF
--- a/gx-util.js
+++ b/gx-util.js
@@ -307,7 +307,7 @@ function Rectangle(x1OrRectangle, y1, x2, y2) {
  */
 function getImageArks(doc) {
   function isImage(sd) {
-    return sd && sd.resourceType && sd.resourceType === "http://gedcomx.org/DigitalArtifact" || sd.resourceType === "http://gedcomx.org/Image";
+    return sd && sd.resourceType && (sd.resourceType === "http://gedcomx.org/DigitalArtifact" || sd.resourceType === "http://gedcomx.org/Image");
   }
 
   function isRecord(sd) {


### PR DESCRIPTION
When sd was null, the equality after the OR was being evaluated, resulting in an error.